### PR TITLE
feat: Add helm v3.6.3 to docker image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules
 testrepo-semantic-composer-releases
+testrepo-semantic-helm-releases
 .tmp
 .DS_STORE

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,9 @@ ENV NODE_PATH=/usr/local/lib/node_modules/
 WORKDIR /github/workspace
 
 RUN apk update \
-    && apk add --no-cache git openssh bash
+    && apk add --no-cache git openssh bash \
+    && apk add curl
+RUN curl -L https://get.helm.sh/helm-v3.6.3-linux-amd64.tar.gz | tar xz && mv linux-amd64/helm /bin/helm && rm -rf linux-amd64
 
 COPY npm-install.sh /opt/
 RUN --mount=type=secret,id=GITHUB_TOKEN /opt/npm-install.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,7 @@ ENV NODE_PATH=/usr/local/lib/node_modules/
 WORKDIR /github/workspace
 
 RUN apk update \
-    && apk add --no-cache git openssh bash \
-    && apk add curl
+    && apk add --no-cache git openssh bash curl
 RUN curl -L https://get.helm.sh/helm-v3.6.3-linux-amd64.tar.gz | tar xz && mv linux-amd64/helm /bin/helm && rm -rf linux-amd64
 
 COPY npm-install.sh /opt/

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,6 +3,11 @@
 set -e
 
 echo ""
+echo "Helm version:"
+helm version
+echo ""
+
+echo ""
 echo "Welcome to semantic-release by Ambimax"
 echo ""
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,12 +3,10 @@
 set -e
 
 echo ""
+echo "Welcome to semantic-release by Ambimax"
+echo ""
 echo "Helm version:"
 helm version
-echo ""
-
-echo ""
-echo "Welcome to semantic-release by Ambimax"
 echo ""
 
 error_exit() {


### PR DESCRIPTION
With this PR the Docker image for semantic-release contains helm with the version 3.6.3. It was necessary to use the plugin `semantic-release-helm`